### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -3,5 +3,5 @@
 - Terminology changes
 
 # Fixes
-- Spaces in export target configuration fields will trigger an error message.
+- Spaces in export target configuration fields will trigger an error message
 - Fix Topology not showing data from enricher

--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -4,3 +4,4 @@
 
 # Fixes
 - Spaces in export target configuration fields will trigger an error message.
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchJobData.cs
@@ -12,8 +12,6 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             CompanyHouseNumberKey = GetValue<string>(configuration, Constants.KeyName.CompanyHouseNumberKey);
             CountryKey = GetValue<string>(configuration, Constants.KeyName.CountryKey);
             OrgNameKey = GetValue<string>(configuration, Constants.KeyName.OrgNameKey);
-            SkipCompanyHouseNumberEntityCodeCreation = GetValue<bool>(configuration, Constants.KeyName.SkipCompanyHouseNumberEntityCodeCreation);
-            SkipCompanyHouseNameEntityCodeCreation = GetValue<bool>(configuration, Constants.KeyName.SkipCompanyHouseNameEntityCodeCreation);
         }
 
         public string ApiKey { get; set; }
@@ -21,8 +19,6 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
         public string CompanyHouseNumberKey { get; set; }
         public string CountryKey { get; set; }
         public string OrgNameKey { get; set; }
-        public bool SkipCompanyHouseNumberEntityCodeCreation { get; set; }
-        public bool SkipCompanyHouseNameEntityCodeCreation { get; set; }
 
         public IDictionary<string, object> ToDictionary()
         {
@@ -33,8 +29,6 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                 { Constants.KeyName.CompanyHouseNumberKey, CompanyHouseNumberKey },
                 { Constants.KeyName.CountryKey, CountryKey },
                 { Constants.KeyName.OrgNameKey, OrgNameKey },
-                { Constants.KeyName.SkipCompanyHouseNumberEntityCodeCreation, SkipCompanyHouseNumberEntityCodeCreation },
-                { Constants.KeyName.SkipCompanyHouseNameEntityCodeCreation, SkipCompanyHouseNameEntityCodeCreation },
             };
         }
     }

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
@@ -108,7 +108,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             IProvider provider)
         {
             var resultItem = result.As<CompanyNew>();
-            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "companiesHouse", resultItem.Data.company_number);
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, GetCodeOrigin(), resultItem.Data.company_number);
             var clue = new Clue(code, context.Organization) { Data = { OriginProviderDefinitionId = Id } };
 
             PopulateMetadata(clue.Data.EntityData, resultItem.Data, request);
@@ -346,17 +346,12 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
         /// <param name="resultCompany">The result item.</param>
         private void PopulateMetadata(IEntityMetadata metadata, CompanyNew resultCompany, IExternalSearchRequest request)
         {
-            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "companiesHouse", resultCompany.company_number);
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, GetCodeOrigin(), resultCompany.company_number);
 
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.OriginEntityCode = code;
             metadata.Name = request.EntityMetaData.Name;
             metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
-
-            if (!string.IsNullOrEmpty(resultCompany.company_name))
-            {
-                metadata.Codes.Add(new EntityCode(EntityType.Organization, GetCodeOrigin(), resultCompany.company_name));
-            }
 
             metadata.DisplayName = resultCompany.company_name.PrintIfAvailable();
 

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
@@ -108,10 +108,10 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             IProvider provider)
         {
             var resultItem = result.As<CompanyNew>();
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "companiesHouse", resultItem.Data.company_number);
+            var clue = new Clue(code, context.Organization) { Data = { OriginProviderDefinitionId = Id } };
 
-            var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization) { Data = { OriginProviderDefinitionId = Id } };
-
-            PopulateMetadata(clue.Data.EntityData, resultItem.Data, request, config);
+            PopulateMetadata(clue.Data.EntityData, resultItem.Data, request);
             yield return clue;
         }
 
@@ -119,7 +119,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             IExternalSearchRequest request, IDictionary<string, object> config, IProvider provider)
         {
             var resultItem = result.As<CompanyNew>();
-            return CreateMetadata(resultItem, request, config);
+            return CreateMetadata(resultItem, request);
         }
 
         public IPreviewImage GetPrimaryEntityPreviewImage(ExecutionContext context, IExternalSearchQueryResult result,
@@ -325,11 +325,11 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             return new ConnectionVerificationResult(response.IsSuccessful, errorMessage);
         }
 
-        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<CompanyNew> resultItem, IExternalSearchRequest request, IDictionary<string, object> config)
+        private IEntityMetadata CreateMetadata(IExternalSearchQueryResult<CompanyNew> resultItem, IExternalSearchRequest request)
         {
             var metadata = new EntityMetadataPart();
 
-            PopulateMetadata(metadata, resultItem.Data, request, config);
+            PopulateMetadata(metadata, resultItem.Data, request);
 
             return metadata;
         }
@@ -344,23 +344,18 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
         /// <summary>Populates the metadata.</summary>
         /// <param name="metadata">The metadata.</param>
         /// <param name="resultCompany">The result item.</param>
-        private void PopulateMetadata(IEntityMetadata metadata, CompanyNew resultCompany, IExternalSearchRequest request, IDictionary<string, object> config)
+        private void PopulateMetadata(IEntityMetadata metadata, CompanyNew resultCompany, IExternalSearchRequest request)
         {
-            var jobData = new CompanyHouseExternalSearchJobData(config);
-            var code = request.EntityMetaData.OriginEntityCode;
+            var code = new EntityCode(request.EntityMetaData.OriginEntityCode.Type, "companiesHouse", resultCompany.company_number);
 
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.OriginEntityCode = code;
             metadata.Name = request.EntityMetaData.Name;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
-            if (!jobData.SkipCompanyHouseNumberEntityCodeCreation)
+            if (!string.IsNullOrEmpty(resultCompany.company_name))
             {
-                metadata.Codes.Add(new EntityCode(request.EntityMetaData.EntityType, GetCodeOrigin(), resultCompany.company_number));
-            }
-
-            if (!jobData.SkipCompanyHouseNameEntityCodeCreation && !string.IsNullOrEmpty(resultCompany.company_name))
-            {
-                metadata.Codes.Add(new EntityCode(request.EntityMetaData.EntityType, GetCodeOrigin(), resultCompany.company_name));
+                metadata.Codes.Add(new EntityCode(EntityType.Organization, GetCodeOrigin(), resultCompany.company_name));
             }
 
             metadata.DisplayName = resultCompany.company_name.PrintIfAvailable();

--- a/src/ExternalSearch.Providers.CompanyHouse/Constants.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/Constants.cs
@@ -101,22 +101,6 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                     Name = KeyName.OrgNameKey,
                     Help = "The vocabulary key that contains the names of companies you want to enrich (e.g., organization.name)."
                 },
-                new()
-                {
-                    DisplayName = $"Skip {Core.Constants.DomainLabels.EntityCode} Creation (Company House Number)",
-                    Type = "checkbox",
-                    IsRequired = false,
-                    Name =  KeyName.SkipCompanyHouseNumberEntityCodeCreation,
-                    Help = $"Toggle to control the creation of new {Core.Constants.DomainLabels.EntityCodes.ToLower()} using the Company House Number."
-                },
-                new()
-                {
-                    DisplayName = $"Skip {Core.Constants.DomainLabels.EntityCode} Creation (Company Name)",
-                    Type = "checkbox",
-                    IsRequired = false,
-                    Name =  KeyName.SkipCompanyHouseNameEntityCodeCreation,
-                    Help = $"Toggle to control the creation of new {Core.Constants.DomainLabels.EntityCodes.ToLower()} using the Company Name."
-                }
             }
         };
 
@@ -145,8 +129,6 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             public const string CompanyHouseNumberKey = "companyHouseNumberKey";
             public const string CountryKey = "countryKey";
             public const string OrgNameKey = "orgNameKey";
-            public const string SkipCompanyHouseNumberEntityCodeCreation = "skipCompanyHouseNumberEntityCodeCreation";
-            public const string SkipCompanyHouseNameEntityCodeCreation = "skipCompanyHouseNameEntityCodeCreation";
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing CompanyHouse data, but the one from other enricher turn into no source (Logo having issue)
![image](https://github.com/user-attachments/assets/1a3ed261-ea1e-48e4-8cb9-e09dfd628259)

## How has it been tested? <!-- Remove if not needed -->
Manually in local

