### PR TITLE
fix: Use company house number to search profile

### DIFF
--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -1,2 +1,5 @@
 # Feature
-feat: Supports enricherv2
+- Supports enricherv2
+
+# Fix
+- Use Company House Number to search for company profile

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
@@ -84,23 +84,37 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                 ? query.QueryParameters[ExternalSearchQueryParameter.Name].FirstOrDefault()
                 : null;
 
-            if (string.IsNullOrEmpty(name))
-            {
-                yield break;
-            }
+            var companyNumber = query.QueryParameters.ContainsKey(ExternalSearchQueryParameter.Identifier)
+                ? query.QueryParameters[ExternalSearchQueryParameter.Identifier].FirstOrDefault()
+                : null;
 
             var client = new CompanyHouseClient(jobData);
-            var companies = client.GetCompanies(name);
-            if (companies == null)
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                var companies = client.GetCompanies(name);
+                if (companies != null)
+                {
+                    foreach (var company in companies.Select(companyResult => client.GetCompany(companyResult.company_number)))
+                    {
+                        yield return new ExternalSearchQueryResult<CompanyNew>(query, company);
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(companyNumber))
             {
                 yield break;
             }
 
-            foreach (var companyResult in companies)
+            var companySearchByNumber = client.GetCompany(companyNumber);
+
+            if (companySearchByNumber == null)
             {
-                var company = client.GetCompany(companyResult.company_number);
-                yield return new ExternalSearchQueryResult<CompanyNew>(query, company);
+                throw new Exception($"Unable to retrieve company profile for Company House Number: {companyNumber}. Please verify if the number is valid.");
             }
+
+            yield return new ExternalSearchQueryResult<CompanyNew>(query, companySearchByNumber);
         }
 
         public IEnumerable<Clue> BuildClues(ExecutionContext context, IExternalSearchQuery query,
@@ -172,10 +186,10 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             var existingResults = request.GetQueryResults<CompanyNew>(this).ToList();
 
             bool idFilter(string value) =>
-                existingResults.Any(r => string.Equals(r.Data.company_number, value, StringComparison.InvariantCultureIgnoreCase));
+                existingResults.Any(r => r?.Data?.company_number != null && string.Equals(r.Data.company_number, value, StringComparison.InvariantCultureIgnoreCase));
 
             bool nameFilter(string value) =>
-                existingResults.Any(r => string.Equals(r.Data.company_name, value, StringComparison.InvariantCultureIgnoreCase));
+                existingResults.Any(r => r?.Data?.company_name != null && string.Equals(r.Data.company_name, value, StringComparison.InvariantCultureIgnoreCase));
 
             var entityType = request.EntityMetaData.EntityType;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#52911](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/52911)

Previously the company house number is not being used for enrichment. Adding the logic so that the search can be done by number.

NOTE:
- Company House enricher will use entity name to perform search even if the vocabulary key is not provided (in InternalBuildQueries() ~line 240 to 248) -----> do we need to remove this?

Error log will be returned if company house number is not in valid format
<img width="1913" height="712" alt="image" src="https://github.com/user-attachments/assets/c85af764-d736-498c-b1ea-b4e07e44ffda" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local

