### PR TITLE
feat: Ability to exclude search using golden record name

### DIFF
--- a/docs/4.6.1-release-notes.md
+++ b/docs/4.6.1-release-notes.md
@@ -1,2 +1,3 @@
 # Feature
 - Added exception messages along the external search pipeline to improve clarity and logging
+- Added a Search Using Golden Record Name toggle that uses the Golden Record name for search when enabled

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchJobData.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchJobData.cs
@@ -12,6 +12,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             CompanyHouseNumberKey = GetValue<string>(configuration, Constants.KeyName.CompanyHouseNumberKey);
             CountryKey = GetValue<string>(configuration, Constants.KeyName.CountryKey);
             OrgNameKey = GetValue<string>(configuration, Constants.KeyName.OrgNameKey);
+            SearchWithEntityName = GetValue<bool>(configuration, Constants.KeyName.SearchWithEntityName);
         }
 
         public string ApiKey { get; set; }
@@ -19,6 +20,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
         public string CompanyHouseNumberKey { get; set; }
         public string CountryKey { get; set; }
         public string OrgNameKey { get; set; }
+        public bool SearchWithEntityName { get; set; }
 
         public IDictionary<string, object> ToDictionary()
         {
@@ -29,6 +31,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                 { Constants.KeyName.CompanyHouseNumberKey, CompanyHouseNumberKey },
                 { Constants.KeyName.CountryKey, CountryKey },
                 { Constants.KeyName.OrgNameKey, OrgNameKey },
+                { Constants.KeyName.SearchWithEntityName, SearchWithEntityName },
             };
         }
     }

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
@@ -238,14 +238,17 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                     Core.Data.Vocabularies.Vocabularies.CluedInOrganization.OrganizationName, new HashSet<string>());
             }
 
-            if (!string.IsNullOrEmpty(request.EntityMetaData.Name))
+            if (jobData.SearchWithEntityName)
             {
-                organizationName.Add(request.EntityMetaData.Name);
-            }
+                if (!string.IsNullOrEmpty(request.EntityMetaData.Name))
+                {
+                    organizationName.Add(request.EntityMetaData.Name);
+                }
 
-            if (!string.IsNullOrEmpty(request.EntityMetaData.DisplayName))
-            {
-                organizationName.Add(request.EntityMetaData.DisplayName);
+                if (!string.IsNullOrEmpty(request.EntityMetaData.DisplayName))
+                {
+                    organizationName.Add(request.EntityMetaData.DisplayName);
+                }
             }
 
             var queriesGenerated = false;

--- a/src/ExternalSearch.Providers.CompanyHouse/Constants.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/Constants.cs
@@ -101,6 +101,14 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
                     Name = KeyName.OrgNameKey,
                     Help = "The vocabulary key that contains the names of companies you want to enrich (e.g., organization.name)."
                 },
+                new()
+                {
+                    DisplayName = "Search using Golden Record Name",
+                    Type = "checkbox",
+                    IsRequired = false,
+                    Name = KeyName.SearchWithEntityName,
+                    Help = "Toggle to control whether the golden record name is used for searching when the organization name vocabulary key is empty or not provided"
+                },
             }
         };
 
@@ -129,6 +137,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             public const string CompanyHouseNumberKey = "companyHouseNumberKey";
             public const string CountryKey = "countryKey";
             public const string OrgNameKey = "orgNameKey";
+            public const string SearchWithEntityName = "searchWithEntityName";
         }
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55367](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55367)

Added a Search using Golden Record Name toggle to allow users to decide if golden record name should be used for searching matches. 
<img width="1432" height="936" alt="image" src="https://github.com/user-attachments/assets/343a7098-9151-4201-b7fc-94f2ef38662a" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local

