### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +24,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -14,7 +14,7 @@
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
     <PackageReference Update="xunit.v3" Version="3.2.2" />
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Update="Moq" Version="4.13.1" />
+    <PackageReference Update="Moq" Version="4.20.72" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
     <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.CompanyHouse.Provider/Provider.ExternalSearch.CompanyHouse.csproj
+++ b/src/ExternalSearch.Providers.CompanyHouse.Provider/Provider.ExternalSearch.CompanyHouse.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseClient.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseClient.cs
@@ -15,7 +15,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
         public CompanyHouseClient(CompanyHouseExternalSearchJobData jobData)
         {
             _client = new RestClient("https://api.companieshouse.gov.uk");
-            _request = new RestRequest { Method = Method.GET };
+            _request = new RestRequest { Method = Method.Get };
             _request.AddHeader("Authorization", "Basic " + Base64Encode(jobData.ApiKey));
         }
 

--- a/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.CompanyHouse/CompanyHouseExternalSearchProvider.cs
@@ -282,7 +282,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
             var jobData = new CompanyHouseExternalSearchJobData(configDict);
 
             var client = new RestClient("https://api.companieshouse.gov.uk");
-            var request = new RestRequest { Method = Method.GET };
+            var request = new RestRequest { Method = Method.Get };
 
             request.AddHeader("Authorization", "Basic " + Base64Encode(jobData.ApiKey));
             request.Resource = $"search/companies?q=Google";
@@ -320,7 +320,7 @@ namespace CluedIn.ExternalSearch.Providers.CompanyHouse
 
         public override IPreviewImage GetPrimaryEntityPreviewImage(ExecutionContext context, IExternalSearchQueryResult result, IExternalSearchRequest request) => throw new NotSupportedException();
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/src/ExternalSearch.Providers.CompanyHouse/ExternalSearch.Providers.CompanyHouse.csproj
+++ b/src/ExternalSearch.Providers.CompanyHouse/ExternalSearch.Providers.CompanyHouse.csproj
@@ -5,13 +5,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\companyhouse.svg" />
   </ItemGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2"/>
+    <PackageReference Include="AutoFixture.Xunit3"/>
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio"/>
     <PackageReference Include="Moq" />
     <PackageReference Include="Shouldly" />

--- a/test/integration/Integration.Tests/CompanyHouseGraphTests.cs
+++ b/test/integration/Integration.Tests/CompanyHouseGraphTests.cs
@@ -8,11 +8,11 @@ using CluedIn.Core.Serialization;
 using CluedIn.Core.Workflows;
 using CluedIn.ExternalSearch;
 using CluedIn.ExternalSearch.Providers.CompanyHouse;
-using CluedIn.Testing.Base.Context;
 using CluedIn.Testing.Base.ExternalSearch;
 using CluedIn.Testing.Base.Processing.Actors;
 using Moq;
 using Xunit;
+using TestContext = CluedIn.Testing.Base.Context.TestContext;
 
 namespace ExternalSearch.CompanyHouse.Integration.Tests
 {
@@ -60,10 +60,10 @@ namespace ExternalSearch.CompanyHouse.Integration.Tests
             context.Workflow = command.Workflow;
 
             // Act
-            var result = actor.ProcessWorkflowStep(context, command);
+            var result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Repeat.SaveResult, result.SaveResult);
 
-            result = actor.ProcessWorkflowStep(context, command);
+            result = actor.ProcessWorkflowStepAsync(context, command).GetAwaiter().GetResult();
             Assert.Equal(WorkflowStepResult.Success.SaveResult, result.SaveResult);
             context.Workflow.AddStepResult(result);
 

--- a/test/integration/Integration.Tests/CompanyHouseGraphTests.cs
+++ b/test/integration/Integration.Tests/CompanyHouseGraphTests.cs
@@ -1,13 +1,21 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Castle.MicroKernel.Registration;
+using CluedIn.Core;
 using CluedIn.Core.Data;
 using CluedIn.Core.Data.Parts;
+using ProviderDefinition = CluedIn.Core.Data.Relational.ProviderDefinition;
+using CluedIn.Core.DataStore;
+using CluedIn.Core.ExternalSearch;
 using CluedIn.Core.Messages.Processing;
 using CluedIn.Core.Processing;
+using CluedIn.Core.Providers;
 using CluedIn.Core.Serialization;
 using CluedIn.Core.Workflows;
 using CluedIn.ExternalSearch;
 using CluedIn.ExternalSearch.Providers.CompanyHouse;
+using CluedIn.ExternalSearch.Providers.CompanyHouse.Model;
 using CluedIn.Testing.Base.ExternalSearch;
 using CluedIn.Testing.Base.Processing.Actors;
 using Moq;
@@ -23,15 +31,18 @@ namespace ExternalSearch.CompanyHouse.Integration.Tests
         {
             // Arrange
             testContext = new TestContext();
+
             var properties = new EntityMetadataPart();
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.Website, "http://sitecore.net");
             properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.AddressCountryCode, "uk");
+            properties.Properties.Add(CluedIn.Core.Data.Vocabularies.Vocabularies.CluedInOrganization.OrganizationName, "Sitecore");
             properties.Properties.Add("Website", "http://sitecore.net.com");
 
             IEntityMetadata entityMetadata = new EntityMetadataPart()
             {
                 Name = "Sitecore",
                 EntityType = EntityType.Organization,
+                OriginEntityCode = new EntityCode(EntityType.Organization, CodeOrigin.CluedIn, "Sitecore"),
                 Properties = properties.Properties
             };
 
@@ -39,10 +50,46 @@ namespace ExternalSearch.CompanyHouse.Integration.Tests
             var clues = new List<CompressedClue>();
 
             externalSearchProvider.CallBase = true;
+            externalSearchProvider.As<IConfigurableExternalSearchProvider>()
+                .Setup(p => p.ExecuteSearch(It.IsAny<ExecutionContext>(), It.IsAny<IExternalSearchQuery>(), It.IsAny<IDictionary<string, object>>(), It.IsAny<IProvider>()))
+                .Returns((ExecutionContext ctx, IExternalSearchQuery q, IDictionary<string, object> c, IProvider p) =>
+                    new IExternalSearchQueryResult[] { new ExternalSearchQueryResult<CompanyNew>(q, new CompanyNew { company_name = "Sitecore", company_number = "12345678" }) });
 
-            testContext.ProcessingHub.Setup(h => h.SendCommand(It.IsAny<ProcessClueCommand>())).Callback<IProcessingCommand>(c => clues.Add(((ProcessClueCommand)c).Clue));
-            //this.testContext.Container.Register(Component.For<IPropertyTranslationService>().UsingFactoryMethod(() => new PropertyTranslationService()));
+            testContext.ProcessingHub
+                .Setup(h => h.SendCommand(It.IsAny<ProcessClueCommand>()))
+                .Callback<IProcessingCommand>(c => clues.Add(((ProcessClueCommand)c).Clue));
+            testContext.ProcessingHub
+                .Setup(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()))
+                .Callback<IProcessingCommand>(c => clues.Add(((ProcessClueCommand)c).Clue))
+                .Returns(Task.CompletedTask);
+
             testContext.Container.Register(Component.For<IExternalSearchProvider>().UsingFactoryMethod(() => externalSearchProvider.Object));
+
+            var providerDefinition = new ProviderDefinition { Id = Guid.NewGuid(), IsEnabled = true };
+            var mockProviderProvider = new Mock<IExternalSearchProviderProvider>();
+            mockProviderProvider.SetupGet(p => p.ExternalSearchProvider).Returns(externalSearchProvider.Object);
+            var mockProviderConfig = new Mock<IExternalSearchProviderConfiguration>();
+            mockProviderConfig.SetupGet(c => c.ExternalSearchProvider).Returns(externalSearchProvider.Object);
+            mockProviderConfig.SetupGet(c => c.Provider).Returns(mockProviderProvider.As<IProvider>().Object);
+            mockProviderConfig.SetupGet(c => c.ProviderDefinition).Returns(providerDefinition);
+            testContext.ExternalSearchProvidersRepository
+                .Setup(r => r.GetProviderConfigurations(It.IsAny<ExecutionContext>(), It.IsAny<IExternalSearchRequest>()))
+                .Returns(new[] { mockProviderConfig.Object });
+            testContext.ExternalSearchProvidersRepository
+                .Setup(r => r.GetProviderConfigurations(It.IsAny<ExecutionContext>()))
+                .Returns(new[] { mockProviderConfig.Object });
+            testContext.ExternalSearchProvidersRepository
+                .Setup(r => r.GetProviderConfiguration(It.IsAny<ExecutionContext>(), It.IsAny<Guid>()))
+                .Returns(mockProviderConfig.Object);
+
+            var mockConfigRepo = new Mock<IConfigurationRepository>();
+            mockConfigRepo
+                .Setup(r => r.GetConfigurationById(It.IsAny<ExecutionContext>(), It.IsAny<Guid>()))
+                .Returns(new Dictionary<string, object>
+                {
+                    { CluedIn.ExternalSearch.Providers.CompanyHouse.Constants.KeyName.AcceptedEntityType, EntityType.Organization.ToString() }
+                });
+            testContext.Container.Register(Component.For<IConfigurationRepository>().Instance(mockConfigRepo.Object));
 
             var context = testContext.Context.ToProcessingContext();
             var command = new ExternalSearchCommand();
@@ -70,7 +117,7 @@ namespace ExternalSearch.CompanyHouse.Integration.Tests
             context.Workflow.ProcessStepResult(context, command);
 
             // Assert
-            testContext.ProcessingHub.Verify(h => h.SendCommand(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
+            testContext.ProcessingHub.Verify(h => h.SendCommandAsync(It.IsAny<ProcessClueCommand>()), Times.AtLeastOnce);
 
             Assert.True(clues.Count > 0);
         }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`